### PR TITLE
throw an error if n<1 in gaussHermiteData

### DIFF
--- a/R/lib.R
+++ b/R/lib.R
@@ -89,5 +89,8 @@ hermitePolyCoef <- function(n) {
 #' Biometrika, 81(3) 624-629.
 #' @keywords math
 gaussHermiteData <- function(n) {
+    if (n < 1) {
+        stop("n must be a positive integer")
+    }
     .Call("gaussHermiteData", n, PACKAGE="fastGHQuad")
 }


### PR DESCRIPTION
previously, n<1 would cause "uncaught exception of type std::length_error: vector," which would crash the R session. 
