### PR TITLE
docs: 2nd derivative of log(g), not g

### DIFF
--- a/R/integrate.R
+++ b/R/integrate.R
@@ -80,7 +80,7 @@ ghQuad <- function(f, rule, ...) {
 #' @param g Function to integrate with respect to first (scalar) argument
 #' @param muHat Mode for Laplace approximation
 #' @param sigmaHat Scale for Laplace approximation (\code{sqrt(-1/H)}, where H
-#' is the second derivative of g at muHat)
+#' is the second derivative of log(g) at muHat)
 #' @param rule Gauss-Hermite quadrature rule to use, as produced by
 #' \code{\link{gaussHermiteData}}
 #' @param ... Additional arguments for g


### PR DESCRIPTION
See Liu and Pierce, between equations 4 and 5.

I didn't re-run roxygen in this pull request because my computer has a newer version of roxygen2 and clutters up the commit history with irrelevant changes to the docs.  I could still add that to this pull request if you wanted, though.
