### PR TITLE
Make gaussHermiteData callable from other packages.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: fastGHQuad
 Type: Package
 Title: Fast Rcpp implementation of Gauss-Hermite quadrature
-Version: 0.2
+Version: 0.2-2
 Date: 2014-08-13
 Author: Alexander W Blocker
 Maintainer: Alexander W Blocker <ablocker@gmail.com>

--- a/inst/include/fastGHQuad.h
+++ b/inst/include/fastGHQuad.h
@@ -1,24 +1,45 @@
 #ifndef RCPP_fastGHQuad_H_
 #define RCPP_fastGHQuad_H_
 
+#include <R.h>
+#include <Rinternals.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 namespace fastGHQuad {
 
   using namespace Rcpp;
 
-  inline int gaussHermiteDataDirect(int n, std::vector<double>* x, std::vector<double>* w) { 
+  int gaussHermiteDataDirect(int n, std::vector<double>* x, std::vector<double>* w) { 
     static int(*fun)(int, std::vector<double>*, std::vector<double>*) = NULL;
-    if (fun == NULL) fun = (int(*)(int, std::vector<double>*, std::vector<double>*))
-      R_GetCCallable("fastGHQuad","gaussHermiteDataDirect");
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("fastGHQuad"))),
+                       R_GlobalEnv);
+      fun = (int(*)(int, std::vector<double>*, std::vector<double>*))
+        R_GetCCallable("fastGHQuad","gaussHermiteDataDirect");
+    }
     return fun(n, x, w);
   }
 
-  inline int gaussHermiteDataGolubWelsch(int n, std::vector<double>* x, std::vector<double>* w) {
+  int gaussHermiteDataGolubWelsch(int n, std::vector<double>* x, std::vector<double>* w) {
     static int(*fun)(int, std::vector<double>*, std::vector<double>*) = NULL;
-    if (fun == NULL) fun =  (int(*)(int, std::vector<double>*, std::vector<double>*))
-      R_GetCCallable("fastGHQuad","gaussHermiteDataGolubWelsch");
+    if (fun == NULL) {
+      Rf_eval(Rf_lang2(Rf_install("loadNamespace"),
+                       Rf_ScalarString(Rf_mkChar("fastGHQuad"))),
+                       R_GlobalEnv);
+      fun =  (int(*)(int, std::vector<double>*, std::vector<double>*))
+        R_GetCCallable("fastGHQuad","gaussHermiteDataGolubWelsch");
+    }
     return fun(n, x, w);
   }
   
 }
+  
+#ifdef __cplusplus
+}
+#endif
 
-#endif // RCPP_fastGHQuad_H_GEN_
+#endif // RCPP_fastGHQuad_H_

--- a/inst/include/fastGHQuad.h
+++ b/inst/include/fastGHQuad.h
@@ -1,0 +1,24 @@
+#ifndef RCPP_fastGHQuad_H_
+#define RCPP_fastGHQuad_H_
+
+namespace fastGHQuad {
+
+  using namespace Rcpp;
+
+  inline int gaussHermiteDataDirect(int n, std::vector<double>* x, std::vector<double>* w) { 
+    static int(*fun)(int, std::vector<double>*, std::vector<double>*) = NULL;
+    if (fun == NULL) fun = (int(*)(int, std::vector<double>*, std::vector<double>*))
+      R_GetCCallable("fastGHQuad","gaussHermiteDataDirect");
+    return fun(n, x, w);
+  }
+
+  inline int gaussHermiteDataGolubWelsch(int n, std::vector<double>* x, std::vector<double>* w) {
+    static int(*fun)(int, std::vector<double>*, std::vector<double>*) = NULL;
+    if (fun == NULL) fun =  (int(*)(int, std::vector<double>*, std::vector<double>*))
+      R_GetCCallable("fastGHQuad","gaussHermiteDataGolubWelsch");
+    return fun(n, x, w);
+  }
+  
+}
+
+#endif // RCPP_fastGHQuad_H_GEN_

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,0 +1,12 @@
+#include "lib.h"
+
+extern "C" {
+
+  void R_init_fastGHQuad(DllInfo *info) {
+    R_RegisterCCallable("fastGHQuad", "gaussHermiteDataDirect",
+                        (DL_FUNC) &gaussHermiteDataDirect);
+    R_RegisterCCallable("fastGHQuad", "gaussHermiteDataGolubWelsch",
+                        (DL_FUNC) &gaussHermiteDataGolubWelsch);
+  }
+  
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -3,6 +3,8 @@
 extern "C" {
 
   void R_init_fastGHQuad(DllInfo *info) {
+    R_registerRoutines(info, NULL, NULL, NULL, NULL);
+    R_useDynamicSymbols(info, TRUE);
     R_RegisterCCallable("fastGHQuad", "gaussHermiteDataDirect",
                         (DL_FUNC) &gaussHermiteDataDirect);
     R_RegisterCCallable("fastGHQuad", "gaussHermiteDataGolubWelsch",

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -1,6 +1,7 @@
 #include "lib.h"
 
 using std::vector;
+using std::abs;
 
 void buildHermiteJacobi(int n, vector<double> *D, vector<double> *E) {
   //
@@ -339,7 +340,7 @@ int gaussHermiteDataDirect(int n, vector<double> *x, vector<double> *w) {
   return 0;
 }
 
-int gaussHermiteData(int n, vector<double> *x, vector<double> *w) {
+int gaussHermiteDataGolubWelsch(int n, vector<double> *x, vector<double> *w) {
   //
   // Calculates nodes & weights for Gauss-Hermite integration of order n
   //
@@ -371,7 +372,7 @@ SEXP gaussHermiteData(SEXP nR) {
   vector<double> x(n), w(n);
 
   // Build Gauss-Hermite integration rules
-  gaussHermiteData(n, &x, &w);
+  gaussHermiteDataGolubWelsch(n, &x, &w);
 
   // Build list for values
   return List::create(Named("x") = x, Named("w") = w);

--- a/src/lib.h
+++ b/src/lib.h
@@ -31,9 +31,9 @@ void quadInfoGolubWelsch(int n, std::vector<double>& D, std::vector<double>& E,
                          double mu0, std::vector<double>& x,
                          std::vector<double>& w);
 
-int gaussHermiteDataDirect(int n, std::vector<double>& x,
-                           std::vector<double>& w);
-int gaussHermiteData(int n, std::vector<double>& x, std::vector<double>& w);
+int gaussHermiteDataDirect(int n, std::vector<double>* x,
+                           std::vector<double>* w);
+int gaussHermiteDataGolubWelsch(int n, std::vector<double>* x, std::vector<double>* w);
 RcppExport SEXP gaussHermiteData(SEXP nR);
 
 #endif


### PR DESCRIPTION
Hi

I've slightly improved upon the other pull request. This one now auto loads the package. This way it's enough to just add fastGHQuad to the other packages' LinkingTo.

R CMD check passes fine locally and on win-builder using R devel. Increase the version number and you should be ready to submit the package to CRAN.

Note that I had to rename one function as function overloading doesn't work when registering C callables.

Best,
Manuel