### PR TITLE
Add USE_FC_LEN_T

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fastGHQuad
 Type: Package
 Title: Fast 'Rcpp' Implementation of Gauss-Hermite Quadrature
-Version: 1.0
-Date: 2018-09-29
+Version: 1.0.1
+Date: 2021-05-22
 Author: Alexander W Blocker
 Maintainer: Alexander W Blocker <ablocker@gmail.com>
 Description: Fast, numerically-stable Gauss-Hermite quadrature rules and

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -147,7 +147,8 @@ void findPolyRoots(const vector<double> &c, int n, vector<double> *r) {
       NULL, &one,          // VR & LDVR; not used
       &tmpwork,            // Workspace; will contain optimal size upon exit
       &LWORK,              // Workspace size; -1 -> get optimal size
-      &INFO FCONE          // Status code
+      &INFO,               // Status code
+      FCONE FCONE
       );
 
   // Next, actually run eigendecomposition
@@ -161,7 +162,8 @@ void findPolyRoots(const vector<double> &c, int n, vector<double> *r) {
       NULL, &one,          // VR & LDVR; not used
       &work[0],            // Workspace; will contain optimal size upon exit
       &LWORK,              // Workspace size; -1 -> get optimal size
-      &INFO FCONE          // Status code
+      &INFO                // Status code
+      FCONE FCONE
       );
 }
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -82,7 +82,7 @@ void quadInfoGolubWelsch(int n, vector<double> &D, vector<double> &E,
   // Run eigen decomposition
   F77_NAME(dstev)(&JOBZ, &n, &D[0], &E[0],  // Job flag & input matrix
                   &Z[0], &n,       // Output array for eigenvectors & dim
-                  &WORK[0], &INFO  // Workspace & info flag
+                  &WORK[0], &INFO FCONE // Workspace & info flag
                   );
 
   // Setup x & w
@@ -147,7 +147,7 @@ void findPolyRoots(const vector<double> &c, int n, vector<double> *r) {
       NULL, &one,          // VR & LDVR; not used
       &tmpwork,            // Workspace; will contain optimal size upon exit
       &LWORK,              // Workspace size; -1 -> get optimal size
-      &INFO                // Status code
+      &INFO FCONE          // Status code
       );
 
   // Next, actually run eigendecomposition
@@ -161,7 +161,7 @@ void findPolyRoots(const vector<double> &c, int n, vector<double> *r) {
       NULL, &one,          // VR & LDVR; not used
       &work[0],            // Workspace; will contain optimal size upon exit
       &LWORK,              // Workspace size; -1 -> get optimal size
-      &INFO                // Status code
+      &INFO FCONE          // Status code
       );
 }
 

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -147,7 +147,7 @@ void findPolyRoots(const vector<double> &c, int n, vector<double> *r) {
       NULL, &one,          // VR & LDVR; not used
       &tmpwork,            // Workspace; will contain optimal size upon exit
       &LWORK,              // Workspace size; -1 -> get optimal size
-      &INFO,               // Status code
+      &INFO                // Status code
       FCONE FCONE
       );
 

--- a/src/lib.h
+++ b/src/lib.h
@@ -5,6 +5,10 @@
 #include <Rcpp.h>
 #include <R_ext/Lapack.h>
 
+#ifndef FCONE
+# define FCONE
+#endif
+
 /*
  * note : RcppExport is an alias to `extern "C"` defined by Rcpp.
  *

--- a/src/lib.h
+++ b/src/lib.h
@@ -1,6 +1,7 @@
 #ifndef _fastGHQuad_LIB_H
 #define _fastGHQuad_LIB_H
 
+#define USE_FC_LEN_T
 #include <Rcpp.h>
 #include <R_ext/Lapack.h>
 


### PR DESCRIPTION
Following guidance from https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Fortran-character-strings and the following note:

> This is a mechanism introduced in R 3.6.2 to change the C/C++ prototypes
of BLAS and LAPACK functions to correspond to code produced by gfortran
 >= 7.  Now that compiler is in near-universal use, it is planned to
make its use obligatory in R 4.2.0, with the switch in R-devel in early
November.
>
> The documentation is in `Writing R Extensions' §6.6.2,
https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Fortran-character-strings
. Note the caveats: USE_FC_LEN_T has to be defined before any R headers
are included.